### PR TITLE
[0002-02] feat: add initial RabbitMQ integration and listener for br.order.create queue

### DIFF
--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/OrderCreateListener.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/OrderCreateListener.java
@@ -1,0 +1,14 @@
+package com.ppm.delivery.order.consumer;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderCreateListener {
+
+    @RabbitListener(queues = "#{createQueue.name}")
+    public void receiveCreateMessage(String message) {
+        System.out.println("Mensagem recebida na fila create: " + message);
+    }
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
@@ -1,0 +1,42 @@
+package com.ppm.delivery.order.consumer.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableRabbit
+public class RabbitConfig {
+
+    @Value("${app.rabbitmq.domain}")
+    private String domain;
+
+    @Value("${app.rabbitmq.country}")
+    private String country;
+
+    @Value("${app.rabbitmq.action-create}")
+    private String actionCreate;
+
+    @Value("${app.rabbitmq.exchange-command}")
+    private String commandExchangeName;
+
+    @Bean
+    public TopicExchange commandExchange() {
+        return new TopicExchange(commandExchangeName);
+    }
+
+    @Bean
+    public Queue createQueue() {
+        String queueName = country + "." + domain + "." + actionCreate;
+        return new Queue(queueName, true);  // durable = true
+    }
+
+    @Bean
+    public Binding bindingCreateQueue(Queue createQueue, TopicExchange commandExchange) {
+        String routingKey = country + "." + actionCreate;
+        return BindingBuilder.bind(createQueue).to(commandExchange).with(routingKey);
+    }
+
+}

--- a/consumer/src/main/resources/application.yml
+++ b/consumer/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+app:
+  rabbitmq:
+    domain: order
+    country: br
+    action-create: create
+    exchange-command: ${app.rabbitmq.domain}.command.exchange

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"     # Porta para comunicação com aplicações
+      - "15672:15672"   # Porta do painel web de administração
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest

--- a/pom.xml
+++ b/pom.xml
@@ -25,4 +25,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
Este PR implementa a integração inicial com o RabbitMQ para o serviço consumidor:

- Adicionada dependência AMQP no pom.xml.

- Configuração de conexão e parâmetros no application.yml.

- Criada RabbitConfig com beans para Exchange, Fila e Binding.

- Criado OrderCreateListener para escutar a fila br.order.create.

- Adicionado serviço do RabbitMQ no docker-compose.yml com painel de administração.

- Validado o recebimento de mensagens via painel do RabbitMQ, confirmando o funcionamento do consumidor.