### PR TITLE
[0002-02] refactor: update RabbitMQ config to support multiple dynamic queues instead of single queue

### DIFF
--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/OrderCreateListener.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/OrderCreateListener.java
@@ -1,14 +1,21 @@
 package com.ppm.delivery.order.consumer;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderCreateListener {
 
-    @RabbitListener(queues = "#{createQueue.name}")
-    public void receiveCreateMessage(String message) {
-        System.out.println("Mensagem recebida na fila create: " + message);
+    @RabbitListener(queues = "#{rabbitConfig.queueNames()}")
+    public void receiveMessage(@Header("amqp_receivedRoutingKey") String routingKey,
+                               String message) {
+
+        System.out.println("Mensagem recebida: " + message);
+        System.out.println("Routing key: " + routingKey);
+
+        String country = routingKey.split("\\.")[0];
+        System.out.println("🌍 País da mensagem: " + country);
     }
 
 }

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
@@ -1,42 +1,89 @@
 package com.ppm.delivery.order.consumer.config;
 
-import org.springframework.amqp.core.*;
+import com.ppm.delivery.order.consumer.properties.MessageProperties;
+import com.ppm.delivery.order.consumer.properties.SupportedCountries;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 @EnableRabbit
 public class RabbitConfig {
 
-    @Value("${app.rabbitmq.domain}")
-    private String domain;
+    private final SupportedCountries supportedCountries;
+    private final MessageProperties messageProperties;
 
-    @Value("${app.rabbitmq.country}")
-    private String country;
-
-    @Value("${app.rabbitmq.action-create}")
-    private String actionCreate;
-
-    @Value("${app.rabbitmq.exchange-command}")
-    private String commandExchangeName;
+    public RabbitConfig(SupportedCountries supportedCountries, MessageProperties messageProperties){
+        this.supportedCountries = supportedCountries;
+        this.messageProperties = messageProperties;
+    }
 
     @Bean
     public TopicExchange commandExchange() {
-        return new TopicExchange(commandExchangeName);
+        return new TopicExchange(messageProperties.getExchange());
     }
 
     @Bean
-    public Queue createQueue() {
-        String queueName = country + "." + domain + "." + actionCreate;
-        return new Queue(queueName, true);  // durable = true
+    public List<Queue> countryQueues() {
+
+        List<Queue> countryQueues = new ArrayList<>();
+        String domain = messageProperties.getDomain();
+        for(String country : supportedCountries.getSupportedCountries()) {
+            for (String action :  messageProperties.getActions()) {
+                countryQueues.add(new Queue(country.toLowerCase() + "." + domain + "." + action, true));
+            }
+        }
+        return countryQueues;
     }
 
     @Bean
-    public Binding bindingCreateQueue(Queue createQueue, TopicExchange commandExchange) {
-        String routingKey = country + "." + actionCreate;
-        return BindingBuilder.bind(createQueue).to(commandExchange).with(routingKey);
+    public List<String> queueNames() {
+        return countryQueues().stream()
+                .map(Queue::getName)
+                .toList();
+    }
+
+    @Bean
+    public List<Binding> createBindings(TopicExchange commandExchange, List<Queue> countryQueues) {
+        List<Binding> bindings = new ArrayList<>();
+        for (Queue queue : countryQueues) {
+            String country = queue.getName().split("\\.")[0];
+
+            for (String action :  messageProperties.getActions()) {
+                String routingKey = country + "." + action;
+                bindings.add(BindingBuilder.bind(queue).to(commandExchange).with(routingKey));
+            }
+        }
+        return bindings;
+    }
+
+    @Bean
+    public RabbitAdmin rabbitAdmin(ConnectionFactory connectionFactory,
+                                   TopicExchange commandExchange,
+                                   List<Queue> countryQueues,
+                                   List<Binding> createBindings) {
+
+        RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+        admin.declareExchange(commandExchange);
+
+        for (Queue queue : countryQueues) {
+            admin.declareQueue(queue);
+        }
+
+        for (Binding binding : createBindings) {
+            admin.declareBinding(binding);
+        }
+
+        return admin;
     }
 
 }

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/MessageProperties.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/MessageProperties.java
@@ -1,0 +1,20 @@
+package com.ppm.delivery.order.consumer.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "message.rabbitmq")
+public class MessageProperties {
+
+    private String domain;
+    private List<String> actions = new ArrayList<>();
+    private String exchange;
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/SupportedCountries.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/SupportedCountries.java
@@ -1,0 +1,17 @@
+package com.ppm.delivery.order.consumer.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app")
+public class SupportedCountries {
+
+    private List<String> supportedCountries;
+}

--- a/consumer/src/main/resources/application.yml
+++ b/consumer/src/main/resources/application.yml
@@ -6,8 +6,16 @@ spring:
     password: guest
 
 app:
+  supportedCountries:
+    - AR
+    - BR
+    - CO
+    - MX
+    - PY
+    - US
+
+message:
   rabbitmq:
     domain: order
-    country: br
-    action-create: create
-    exchange-command: ${app.rabbitmq.domain}.command.exchange
+    actions: create, update
+    exchange: order.command.exchange

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,19 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Refactor da configuração do RabbitMQ para suportar múltiplas filas dinâmicas por país, registradas via RabbitAdmin.

- Atualiza o listener e as propriedades para consumir mensagens em filas específicas.

- Garante maior flexibilidade e escalabilidade ao sistema.