### PR TITLE
[0002-04] test: add comprehensive unit tests for RabbitConfig with scenario coverage and refactor queueNames

### DIFF
--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
@@ -52,8 +52,8 @@ public class RabbitConfig {
     }
 
     @Bean
-    public List<String> queueNames() {
-        return countryQueues().stream()
+    public List<String> queueNames(List<Queue> countryQueues) {
+        return countryQueues.stream()
                 .map(Queue::getName)
                 .toList();
     }

--- a/consumer/src/test/java/com/ppm/delivery/order/consumer/config/RabbitConfigTest.java
+++ b/consumer/src/test/java/com/ppm/delivery/order/consumer/config/RabbitConfigTest.java
@@ -1,0 +1,202 @@
+package com.ppm.delivery.order.consumer.config;
+
+import com.ppm.delivery.order.consumer.properties.MessageProperties;
+import com.ppm.delivery.order.consumer.properties.SupportedCountries;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RabbitConfigTest {
+
+    @Mock
+    private SupportedCountries supportedCountries;
+
+    @Mock
+    private MessageProperties messageProperties;
+
+    private RabbitConfig rabbitConfig;
+
+    @BeforeEach
+    void setUp() {
+        rabbitConfig = new RabbitConfig(supportedCountries, messageProperties);
+    }
+
+    @Test
+    void commandExchange_shouldUseExchangeFromProperties() {
+        //Arrange
+        when(messageProperties.getExchange()).thenReturn("my.exchange");
+
+        //Act
+        TopicExchange exchange = rabbitConfig.commandExchange();
+
+        //Assert
+        assertNotNull(exchange);
+        assertEquals("my.exchange", exchange.getName());
+
+        verify(messageProperties).getExchange();
+        verifyNoMoreInteractions(messageProperties, supportedCountries);
+    }
+
+    @Test
+    void countryQueues_shouldCreateQueuesForEachCountryAndAction_andPopulateNamesCorrectly() {
+        //Arrange
+        when(messageProperties.getDomain()).thenReturn("order");
+        when(messageProperties.getActions()).thenReturn(List.of("create", "update"));
+        when(supportedCountries.getSupportedCountries()).thenReturn(List.of("BR", "US"));
+
+        //Act
+        List<Queue> queues = rabbitConfig.countryQueues();
+
+        //Assert
+        Set<String> expectedNames = Set.of(
+                "br.order.create",
+                "br.order.update",
+                "us.order.create",
+                "us.order.update"
+        );
+
+        Set<String> actualNames = queues.stream()
+                .map(Queue::getName)
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedNames, actualNames);
+        assertTrue(queues.stream().allMatch(Queue::isDurable));
+
+        verify(supportedCountries).getSupportedCountries();
+        verify(messageProperties).getDomain();
+        verify(messageProperties, atLeastOnce()).getActions();
+        verifyNoMoreInteractions(messageProperties, supportedCountries);
+    }
+
+    @Test
+    void queueNames_shouldReturnNamesDerivedFromCountryQueues() {
+        //Arrange
+        when(messageProperties.getDomain()).thenReturn("order");
+        when(messageProperties.getActions()).thenReturn(List.of("create"));
+        when(supportedCountries.getSupportedCountries()).thenReturn(List.of("BR"));
+
+        //Act
+        List<Queue> queues = rabbitConfig.countryQueues();
+        List<String> queueNames = rabbitConfig.queueNames(queues);
+
+        //Assert
+        assertEquals(1, queueNames.size());
+        assertEquals("br.order.create", queueNames.get(0));
+
+        verify(supportedCountries).getSupportedCountries();
+        verify(messageProperties).getDomain();
+        verify(messageProperties).getActions();
+        verifyNoMoreInteractions(messageProperties, supportedCountries);
+    }
+
+    @Test
+    void createBindings_shouldBindEachQueueWithCorrectRoutingKey() {
+        //Arrange
+        when(messageProperties.getDomain()).thenReturn("order");
+        when(messageProperties.getActions()).thenReturn(List.of("create", "delete"));
+        when(supportedCountries.getSupportedCountries()).thenReturn(List.of("BR", "MX"));
+        when(messageProperties.getExchange()).thenReturn("commands");
+
+        //Act
+        TopicExchange exchange = rabbitConfig.commandExchange();
+        List<Queue> countryQueues = rabbitConfig.countryQueues();
+        List<Binding> bindings = rabbitConfig.createBindings(exchange, countryQueues);
+
+        //Assert
+        Set<String> expectedRoutingKeys = Set.of(
+                "br.create",
+                "br.delete",
+                "mx.create",
+                "mx.delete"
+        );
+
+        Set<String> actualRoutingKeys = bindings.stream()
+                .map(Binding::getRoutingKey)
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedRoutingKeys, actualRoutingKeys);
+
+        assertTrue(bindings.stream().allMatch(b -> b.getExchange().equals(exchange.getName())));
+
+        Set<String> bindingDestinations = bindings.stream()
+                .map(Binding::getDestination)
+                .collect(Collectors.toSet());
+        Set<String> queueNames = countryQueues.stream().map(Queue::getName).collect(Collectors.toSet());
+        assertEquals(queueNames, bindingDestinations);
+
+        verify(supportedCountries).getSupportedCountries();
+        verify(messageProperties).getDomain();
+        verify(messageProperties, atLeastOnce()).getActions();
+        verify(messageProperties).getExchange();
+        verifyNoMoreInteractions(messageProperties, supportedCountries);
+
+    }
+
+    @Test
+    void whenNoActions_butHasSupportedCountries_thenNoQueuesOrBindingsCreated() {
+        //Arrange
+        when(messageProperties.getDomain()).thenReturn("order");
+        when(messageProperties.getActions()).thenReturn(List.of());
+        when(supportedCountries.getSupportedCountries()).thenReturn(List.of("BR"));
+        when(messageProperties.getExchange()).thenReturn("cmd");
+
+        //Act
+        List<Queue> queues = rabbitConfig.countryQueues();
+
+        //Assert
+        assertTrue(queues.isEmpty());
+
+        List<String> names = rabbitConfig.queueNames(queues);
+        assertTrue(names.isEmpty());
+
+        TopicExchange exchange = rabbitConfig.commandExchange();
+        List<Binding> bindings = rabbitConfig.createBindings(exchange, queues);
+        assertTrue(bindings.isEmpty());
+
+        verify(supportedCountries).getSupportedCountries();
+        verify(messageProperties).getDomain();
+        verify(messageProperties).getActions();
+        verify(messageProperties).getExchange();
+        verifyNoMoreInteractions(supportedCountries, messageProperties);
+    }
+
+    @Test
+    void whenNoSupportedCountries_butHasActions_thenNoQueuesOrBindingsCreated() {
+        //Arrange
+        when(messageProperties.getDomain()).thenReturn("order");
+        when(supportedCountries.getSupportedCountries()).thenReturn(List.of());
+        when(messageProperties.getExchange()).thenReturn("cmd");
+
+        //Act
+        List<Queue> queues = rabbitConfig.countryQueues();
+
+        //Assert
+        assertTrue(queues.isEmpty());
+
+        List<String> names = rabbitConfig.queueNames(queues);
+        assertTrue(names.isEmpty());
+
+        TopicExchange exchange = rabbitConfig.commandExchange();
+        List<Binding> bindings = rabbitConfig.createBindings(exchange, queues);
+        assertTrue(bindings.isEmpty());
+
+        verify(supportedCountries).getSupportedCountries();
+        verify(messageProperties).getDomain();
+        verify(messageProperties).getExchange();
+        verifyNoMoreInteractions(messageProperties, supportedCountries);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.34</lombok.version>
+        <junit.jupiter.version>5.10.0</junit.jupiter.version>
+        <mockito.jupiter.version>5.3.1</mockito.jupiter.version>
     </properties>
 
     <dependencies>
@@ -37,6 +39,20 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Este PR adiciona testes unitários completos para o RabbitConfig, validando a criação dinâmica de exchanges, filas, nomes de filas e bindings com diferentes cenários.

Principais pontos:

- Cobertura de cenários com ausência de países, ausência de ações e múltiplas combinações de país + ação.

- Verificações rigorosas de interações com SupportedCountries e MessageProperties usando Mockito, para garantir chamadas corretas e evitar chamadas desnecessárias.

- Refatoração leve no método queueNames para receber a lista de filas como parâmetro, aumentando a eficiência e testabilidade.

- Atualização no pom.xml para garantir suporte adequado a testes unitários.

