### PR TITLE
[0002-05] feat: (producer) create interceptor for header validation

### DIFF
--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/config/RabbitConfig.java
@@ -52,8 +52,8 @@ public class RabbitConfig {
     }
 
     @Bean
-    public List<String> queueNames(List<Queue> countryQueues) {
-        return countryQueues.stream()
+    public List<String> queueNames() {
+        return countryQueues().stream()
                 .map(Queue::getName)
                 .toList();
     }

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderCreateListener {
 
-    @RabbitListener(queues = "#{rabbitConfig.queueNames()}")
+    @RabbitListener(queues = "#{@rabbitConfig.queueNames()}")
     public void receiveMessage(@Header("amqp_receivedRoutingKey") String routingKey,
                                String message) {
 

--- a/consumer/src/test/java/com/ppm/delivery/order/consumer/config/RabbitConfigTest.java
+++ b/consumer/src/test/java/com/ppm/delivery/order/consumer/config/RabbitConfigTest.java
@@ -90,15 +90,15 @@ public class RabbitConfigTest {
 
         //Act
         List<Queue> queues = rabbitConfig.countryQueues();
-        List<String> queueNames = rabbitConfig.queueNames(queues);
+        List<String> queueNames = rabbitConfig.queueNames();
 
         //Assert
         assertEquals(1, queueNames.size());
         assertEquals("br.order.create", queueNames.get(0));
 
-        verify(supportedCountries).getSupportedCountries();
-        verify(messageProperties).getDomain();
-        verify(messageProperties).getActions();
+        verify(supportedCountries, times(2)).getSupportedCountries();
+        verify(messageProperties, times(2)).getDomain();
+        verify(messageProperties, times(2)).getActions();
         verifyNoMoreInteractions(messageProperties, supportedCountries);
     }
 
@@ -159,16 +159,16 @@ public class RabbitConfigTest {
         //Assert
         assertTrue(queues.isEmpty());
 
-        List<String> names = rabbitConfig.queueNames(queues);
+        List<String> names = rabbitConfig.queueNames();
         assertTrue(names.isEmpty());
 
         TopicExchange exchange = rabbitConfig.commandExchange();
         List<Binding> bindings = rabbitConfig.createBindings(exchange, queues);
         assertTrue(bindings.isEmpty());
 
-        verify(supportedCountries).getSupportedCountries();
-        verify(messageProperties).getDomain();
-        verify(messageProperties).getActions();
+        verify(supportedCountries, times(2)).getSupportedCountries();
+        verify(messageProperties, times(2)).getDomain();
+        verify(messageProperties, times(2)).getActions();
         verify(messageProperties).getExchange();
         verifyNoMoreInteractions(supportedCountries, messageProperties);
     }
@@ -186,15 +186,15 @@ public class RabbitConfigTest {
         //Assert
         assertTrue(queues.isEmpty());
 
-        List<String> names = rabbitConfig.queueNames(queues);
+        List<String> names = rabbitConfig.queueNames();
         assertTrue(names.isEmpty());
 
         TopicExchange exchange = rabbitConfig.commandExchange();
         List<Binding> bindings = rabbitConfig.createBindings(exchange, queues);
         assertTrue(bindings.isEmpty());
 
-        verify(supportedCountries).getSupportedCountries();
-        verify(messageProperties).getDomain();
+        verify(supportedCountries, times(2)).getSupportedCountries();
+        verify(messageProperties, times(2)).getDomain();
         verify(messageProperties).getExchange();
         verifyNoMoreInteractions(messageProperties, supportedCountries);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <version>${mockito.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/config/InterceptorConfig.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/config/InterceptorConfig.java
@@ -1,0 +1,19 @@
+package com.ppm.delivery.order.producer.api.config;
+
+import com.ppm.delivery.order.producer.api.interceptor.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private RequestInterceptor requestInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(requestInterceptor);
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/config/OrderProducerConfig.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/config/OrderProducerConfig.java
@@ -1,0 +1,30 @@
+package com.ppm.delivery.order.producer.api.config;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "app")
+@Validated
+public class OrderProducerConfig {
+
+    @NotEmpty(message = "Supported countries cannot be empty.")
+    private List<String> supportedCountries;
+
+    public OrderProducerConfig() {
+        supportedCountries = new ArrayList<>();
+    }
+
+    public List<String> getSupportedCountries() {
+        return supportedCountries;
+    }
+
+    public void setSupportedCountries(List<String> supportedCountries) {
+        this.supportedCountries = supportedCountries;
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/constants/HeaderConstants.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/constants/HeaderConstants.java
@@ -1,0 +1,19 @@
+package com.ppm.delivery.order.producer.api.constants;
+
+public class HeaderConstants {
+
+    public static final String HEADER_CORRELATION_ID = "correlationId";
+    public static final String HEADER_TIMESTAMP = "timestamp";
+    public static final String HEADER_SOURCE = "source";
+    public static final String HEADER_AUTHORIZATION = "authorization";
+    public static final String HEADER_TYPE = "type";
+    public static final String HEADER_EVENT_NAME = "event-name";
+    public static final String HEADER_EVENT_VERSION = "event-version";
+    public static final String HEADER_USER_INFO_ID = "userInfo-id";
+    public static final String HEADER_USER_INFO_PROFILE = "userInfo-profile";
+    public static final String HEADER_COUNTRY = "country";
+    public static final String HEADER_PLATFORM = "platform";
+    public static final String HEADER_PROFILE = "profile";
+
+    private HeaderConstants() {}
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/context/ContextHolder.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/context/ContextHolder.java
@@ -1,0 +1,19 @@
+package com.ppm.delivery.order.producer.api.context;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Getter
+@RequestScope
+@Component
+public class ContextHolder {
+
+    private String country;
+    private String profile;
+
+    public void initializeContext(final String country, final String profile) {
+        this.country = country;
+        this.profile = profile;
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/profile/Profile.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/profile/Profile.java
@@ -1,0 +1,5 @@
+package com.ppm.delivery.order.producer.api.domain.profile;
+
+public enum Profile {
+    ADMIN, USER
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Event.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Event.java
@@ -1,0 +1,6 @@
+package com.ppm.delivery.order.producer.api.domain.request.header;
+
+public record Event (
+        String name,
+        String version)
+{}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Header.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Header.java
@@ -1,0 +1,14 @@
+package com.ppm.delivery.order.producer.api.domain.request.header;
+
+import java.time.Instant;
+
+public record Header(
+        String correlationId,
+        Instant timestamp,
+        String source,
+        String authorization,
+        String type,
+        Event event,
+        UserInfo userInfo,
+        Metadata metadata
+) {}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Metadata.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/Metadata.java
@@ -1,0 +1,7 @@
+package com.ppm.delivery.order.producer.api.domain.request.header;
+
+public record Metadata(
+        String country,
+        String platform,
+        String profile) {
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/UserInfo.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/header/UserInfo.java
@@ -1,0 +1,6 @@
+package com.ppm.delivery.order.producer.api.domain.request.header;
+
+public record UserInfo(
+        String id,
+        String profile) {
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/HeaderValidationException.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/HeaderValidationException.java
@@ -1,0 +1,11 @@
+package com.ppm.delivery.order.producer.api.exception;
+
+public class HeaderValidationException extends RuntimeException{
+    public HeaderValidationException(String message) {
+        super(message);
+    }
+
+    public HeaderValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/MessageErrorConstants.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/MessageErrorConstants.java
@@ -1,0 +1,13 @@
+package com.ppm.delivery.order.producer.api.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MessageErrorConstants {
+
+    public static final String ERROR_COUNTRY_REQUIRED_HEADER = "Country is required in the request header";
+    public static final String ERROR_COUNTRY_NOT_SUPPORTED = "Country not supported: %s";
+    public static final String ERROR_PROFILE_REQUIRED_HEADER = "Profile is required in the request header";
+    public static final String ERROR_PROFILE_IS_INVALID = "Profile is Invalid";
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/PPMApiExceptionHandler.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/PPMApiExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.ppm.delivery.order.producer.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class PPMApiExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+
+        StringBuilder errors = new StringBuilder();
+        bindingResult.getFieldErrors().forEach(error -> {
+            errors.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("\n");
+        });
+
+        return new ResponseEntity<>(errors.toString(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HeaderValidationException.class)
+    public ResponseEntity<Map<String, String>> handleHeaderValidationException(HeaderValidationException  ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/TimestampInvalidException.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/exception/TimestampInvalidException.java
@@ -1,0 +1,11 @@
+package com.ppm.delivery.order.producer.api.exception;
+
+public class TimestampInvalidException extends HeaderValidationException {
+
+    public TimestampInvalidException(String message) {
+        super(message);
+    }
+    public TimestampInvalidException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/validation/RequestValidator.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/validation/RequestValidator.java
@@ -1,0 +1,54 @@
+package com.ppm.delivery.order.producer.api.validation;
+
+import com.ppm.delivery.order.producer.api.config.OrderProducerConfig;
+import com.ppm.delivery.order.producer.api.domain.profile.Profile;
+import com.ppm.delivery.order.producer.api.domain.request.header.Header;
+import com.ppm.delivery.order.producer.api.exception.MessageErrorConstants;
+import com.ppm.delivery.order.producer.exception.CountryNotSupportedException;
+import com.ppm.delivery.order.producer.exception.ProfileNotSupportedException;
+import io.micrometer.common.util.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+@Component
+public class RequestValidator {
+
+    private final OrderProducerConfig orderProducerConfig;
+
+    public RequestValidator(final OrderProducerConfig orderProducerConfig) {
+        this.orderProducerConfig = Objects.requireNonNull(orderProducerConfig);
+    }
+
+    public void validateHeader(final Header header){
+        validateCountry(header.metadata().country());
+        validateProfile(header.metadata().profile());
+    }
+
+    private void validateCountry(final String country){
+
+        if (StringUtils.isBlank(country)) {
+            throw new CountryNotSupportedException(MessageErrorConstants.ERROR_COUNTRY_REQUIRED_HEADER);
+        }
+
+        List<String> supportedCountries = orderProducerConfig.getSupportedCountries();
+        if (supportedCountries == null || !supportedCountries.contains(country)) {
+            throw new CountryNotSupportedException(String.format(MessageErrorConstants.ERROR_COUNTRY_NOT_SUPPORTED, country));
+        }
+    }
+
+    private void validateProfile(final String profile){
+
+        if (StringUtils.isBlank(profile)) {
+            throw new ProfileNotSupportedException(MessageErrorConstants.ERROR_PROFILE_REQUIRED_HEADER);
+        }
+
+        try {
+            Profile.valueOf(profile.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new ProfileNotSupportedException(MessageErrorConstants.ERROR_PROFILE_IS_INVALID);
+        }
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/exception/CountryNotSupportedException.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/exception/CountryNotSupportedException.java
@@ -1,0 +1,9 @@
+package com.ppm.delivery.order.producer.exception;
+
+import com.ppm.delivery.order.producer.api.exception.HeaderValidationException;
+
+public class CountryNotSupportedException extends HeaderValidationException {
+    public CountryNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/exception/ProfileNotSupportedException.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/exception/ProfileNotSupportedException.java
@@ -1,0 +1,9 @@
+package com.ppm.delivery.order.producer.exception;
+
+import com.ppm.delivery.order.producer.api.exception.HeaderValidationException;
+
+public class ProfileNotSupportedException extends HeaderValidationException {
+    public ProfileNotSupportedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## O que foi feito:
- Criado RequestInterceptor para capturar e validar headers obrigatórios.
- Implementado RequestValidator com validações de country e profile.
- Criadas exceções específicas (CountryNotSupportedException, ProfileNotSupportedException, TimestampInvalidException).
- Adicionados DTOs de header: Header, Event, Metadata, UserInfo.
- Criado ContextHolder com escopo de request para armazenar country e profile.
- Configurado PPMApiExceptionHandler para retorno padronizado de erro em JSON.
- Ajustado parsing de timestamp para aceitar ISO-8601 com offset/`Z`.