### PR TITLE
[0002-07] feat: receive headers in consumer and save in context

### DIFF
--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/api/constants/HeaderConstants.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/api/constants/HeaderConstants.java
@@ -1,0 +1,8 @@
+package com.ppm.delivery.order.consumer.api.constants;
+
+public class HeaderConstants {
+
+    public static final String HEADER_COUNTRY = "country";
+    public static final String HEADER_CORRELATION_ID = "correlationId";
+    public static final String HEADER_X_TIMESTAMP = "timestamp";
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/api/context/MessageContextHolder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/api/context/MessageContextHolder.java
@@ -1,0 +1,24 @@
+package com.ppm.delivery.order.consumer.api.context;
+
+import com.ppm.delivery.order.consumer.api.domain.Context;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@RequestScope
+@Component
+public class MessageContextHolder {
+
+    private static final ThreadLocal<Context> contextHolder = new ThreadLocal<>();
+
+    public static void setContext(Context context) {
+        contextHolder.set(context);
+    }
+
+    public static Context getContext() {
+        return contextHolder.get();
+    }
+
+    public static void clear() {
+        contextHolder.remove();
+    }
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/api/domain/Context.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/api/domain/Context.java
@@ -1,0 +1,17 @@
+package com.ppm.delivery.order.consumer.api.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Context {
+
+    private String country;
+    private String correlationId;
+    private Long timestamp;
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
@@ -1,7 +1,11 @@
 package com.ppm.delivery.order.consumer.message.listener;
 
+import com.ppm.delivery.order.consumer.api.constants.HeaderConstants;
+import com.ppm.delivery.order.consumer.api.context.MessageContextHolder;
+import com.ppm.delivery.order.consumer.api.domain.Context;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,13 +13,23 @@ public class OrderCreateListener {
 
     @RabbitListener(queues = "#{@rabbitConfig.queueNames()}")
     public void receiveMessage(@Header("amqp_receivedRoutingKey") String routingKey,
-                               String message) {
+                               @Header(value = HeaderConstants.HEADER_COUNTRY, required = true) final String country,
+                               @Header(value = HeaderConstants.HEADER_CORRELATION_ID, required = true) final String correlationId,
+                               @Header(value = HeaderConstants.HEADER_X_TIMESTAMP, required = true) final Long timestamp,
+                               @Payload final String message) {
 
-        System.out.println("Mensagem recebida: " + message);
-        System.out.println("Routing key: " + routingKey);
+        MessageContextHolder.setContext(new Context(country, correlationId, timestamp));
 
-        String country = routingKey.split("\\.")[0];
-        System.out.println("🌍 País da mensagem: " + country);
+        try {
+            System.out.println("Routing key: " + routingKey);
+            System.out.println("Country: " + country);
+            System.out.println("Correlation ID: " + correlationId);
+            System.out.println("Timestamp: " + timestamp);
+            System.out.println("Mensagem: " + message);
+
+        } finally {
+            MessageContextHolder.clear();
+        }
     }
 
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/service/SenderMessageService.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/service/SenderMessageService.java
@@ -43,7 +43,7 @@ public class SenderMessageService implements ISenderMessageService{
         messageProperties.setHeader(MessageHeaderConstants.HEADER_COUNTRY, contextHolder.getCountry());
         messageProperties.setHeader(MessageHeaderConstants.HEADER_CORRELATION_ID, contextHolder.getCorrelationId());
         messageProperties.setHeader(MessageHeaderConstants.HEADER_PROFILE, contextHolder.getProfile());
-        messageProperties.setHeader(MessageHeaderConstants.HEADER_TIMESTAMP, LocalDateTime.now());
+        messageProperties.setHeader(MessageHeaderConstants.HEADER_TIMESTAMP, LocalDateTime.now().toString());
 
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter();
         return converter.toMessage(payload, messageProperties);


### PR DESCRIPTION
- Criada a classe HeaderConstants para definir os nomes dos headers enviados pelo producer.

- Implementada a classe MessageContextHolder para armazenar as informações recebidas via headers das mensagens.

- Criada a entidade Context para representar o contexto das informações extraídas dos headers.

- Modificado o listener OrderCreateListener para receber os headers country, correlationId e timestamp via anotação @Header e o payload via @Payload.

- Ajustada a classe SenderMessageService do producer para envio dos headers conforme o padrão definido.

- Organização e ajustes para o consumo correto dos headers enviados pelo producer, preparando o contexto para uso posterior.