### PR TITLE
[0002-08] feat: (producer) send OrderRequest with validation and context headers

### DIFF
--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/controller/IOrderProducerController.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/controller/IOrderProducerController.java
@@ -1,5 +1,7 @@
 package com.ppm.delivery.order.producer.api.controller;
 
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -7,5 +9,5 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface IOrderProducerController {
 
     @PostMapping("/create")
-    ResponseEntity<String> create(@RequestBody String message);
+    ResponseEntity<String> create(@RequestBody @Valid OrderRequest request);
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/controller/OrderProducerController.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/controller/OrderProducerController.java
@@ -1,6 +1,8 @@
 package com.ppm.delivery.order.producer.api.controller;
 
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
 import com.ppm.delivery.order.producer.service.IOrderService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,8 +20,8 @@ public class OrderProducerController implements IOrderProducerController{
     }
 
    @Override
-    public ResponseEntity<String> create(@RequestBody String message) {
-        orderService.sendCreateOrderMessage(message);
+    public ResponseEntity<String> create(@RequestBody @Valid OrderRequest request) {
+        orderService.sendCreateOrderMessage(request);
         return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/CupomRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/CupomRequest.java
@@ -1,0 +1,27 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.DiscountType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CupomRequest {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    private BigDecimal discount;
+
+    @NotBlank
+    private DiscountType discountType;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/CustomerInfoRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/CustomerInfoRequest.java
@@ -1,0 +1,22 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerInfoRequest {
+
+    @NotBlank
+    private String id;
+
+    @Email
+    @NotBlank
+    private String email;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/DeliveryInfoRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/DeliveryInfoRequest.java
@@ -1,0 +1,19 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeliveryInfoRequest {
+
+    @NotNull
+    @Valid
+    private LocationRequest location;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/GeoCoordinatesRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/GeoCoordinatesRequest.java
@@ -1,0 +1,20 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeoCoordinatesRequest {
+
+    @NotBlank
+    private Double latitude;
+
+    @NotBlank
+    private Double longitude;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/ItemRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/ItemRequest.java
@@ -1,0 +1,49 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.ItemCategory;
+import com.ppm.delivery.order.producer.domain.enums.ItemTemperature;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemRequest {
+
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private String sku;
+
+    @NotBlank
+    private ItemCategory category;
+
+    @NotBlank
+    private String brand;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private Boolean alcoholic;
+
+    @NotBlank
+    private ItemTemperature temperature;
+
+    @NotNull
+    @Valid
+    private PackageInfoRequest packageInfo;
+
+    @NotNull
+    @Valid
+    private List<@Valid PriceRequest> price;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/LocationRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/LocationRequest.java
@@ -1,0 +1,38 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationRequest {
+
+    @NotNull
+    @Valid
+    private GeoCoordinatesRequest geoCoordinates;
+
+    @NotBlank
+    private String city;
+
+    @NotBlank
+    private String country;
+
+    @NotBlank
+    private String state;
+
+    @NotBlank
+    private String number;
+
+    @NotBlank
+    private String zipCode;
+
+    @NotBlank
+    private String streetAddress;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/OrderRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/OrderRequest.java
@@ -1,0 +1,48 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.Status;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequest {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    private LocalDateTime createDate;
+
+    @NotBlank
+    private Status status;
+
+    @NotNull
+    @Valid
+    private CustomerInfoRequest customerInfo;
+
+    @NotNull
+    @Valid
+    private DeliveryInfoRequest deliveryInfo;
+
+    @NotNull
+    @Valid
+    private List<@Valid ItemRequest> items;
+
+    @NotNull
+    @Valid
+    private PaymentRequest payment;
+
+    @Valid
+    private CupomRequest cupom;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PackageInfoRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PackageInfoRequest.java
@@ -1,0 +1,31 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.PackageType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PackageInfoRequest {
+
+    @NotNull
+    private Integer itemCount;
+
+    @NotBlank
+    private PackageType type;
+
+    @NotBlank
+    private String unitOfMeasurement;
+
+    @NotNull
+    private Boolean returnable;
+
+    @NotNull
+    private Integer size;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PaymentRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PaymentRequest.java
@@ -1,0 +1,43 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.DiscountType;
+import com.ppm.delivery.order.producer.domain.enums.PaymentMethod;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentRequest {
+
+    @NotBlank
+    private PaymentMethod method;
+
+    @NotNull
+    private BigDecimal discount;
+
+    @NotBlank
+    private DiscountType discountType;
+
+    @NotNull
+    private BigDecimal total;
+
+    @NotNull
+    private BigDecimal taxAmount;
+
+    @NotNull
+    private BigDecimal price;
+
+    @NotNull
+    @Valid
+    private List<@Valid TaxRequest> taxes;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PriceRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/PriceRequest.java
@@ -1,0 +1,33 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import com.ppm.delivery.order.producer.domain.enums.PriceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PriceRequest {
+
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private PriceType type;
+
+    @NotNull
+    private BigDecimal price;
+
+    @NotNull
+    private BigDecimal total;
+
+    @NotNull
+    private BigDecimal discountAmount;
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/TaxRequest.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/api/domain/request/TaxRequest.java
@@ -1,0 +1,24 @@
+package com.ppm.delivery.order.producer.api.domain.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaxRequest {
+
+    @NotBlank
+    private String id;
+
+    @NotNull
+    private BigDecimal value;
+
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/DiscountType.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/DiscountType.java
@@ -1,0 +1,7 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum DiscountType {
+
+    VALOR,
+    PORCENTAGEM
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/ItemCategory.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/ItemCategory.java
@@ -1,0 +1,8 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum ItemCategory {
+
+    REFRIGERANTE,
+    CERVEJA,
+    OUTROS
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/ItemTemperature.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/ItemTemperature.java
@@ -1,0 +1,7 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum ItemTemperature {
+
+    NATURAL,
+    GELADO
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PackageType.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PackageType.java
@@ -1,0 +1,8 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum PackageType {
+
+    LATA,
+    LATAO,
+    GARRAFA
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PaymentMethod.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PaymentMethod.java
@@ -1,0 +1,9 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum PaymentMethod {
+
+    DINHEIRO,
+    CARTAO_CREDITO,
+    CARTAO_DEBITO,
+    PIX
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PriceType.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/PriceType.java
@@ -1,0 +1,7 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum PriceType {
+
+    UNIDADE,
+    GRANEL
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/Status.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/domain/enums/Status.java
@@ -1,0 +1,9 @@
+package com.ppm.delivery.order.producer.domain.enums;
+
+public enum Status {
+
+    PENDING,
+    CONFIRMED,
+    CANCELLED,
+    DELIVERED
+}

--- a/producer/src/main/java/com/ppm/delivery/order/producer/service/IOrderService.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/service/IOrderService.java
@@ -1,6 +1,8 @@
 package com.ppm.delivery.order.producer.service;
 
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
+
 public interface IOrderService {
 
-    void sendCreateOrderMessage(String message);
+    void sendCreateOrderMessage(OrderRequest request);
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/service/ISenderMessageService.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/service/ISenderMessageService.java
@@ -1,6 +1,8 @@
 package com.ppm.delivery.order.producer.service;
 
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
+
 public interface ISenderMessageService {
 
-    void sendCreateOrderMessage(Object payload);
+    void sendCreateOrderMessage(OrderRequest request);
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/service/OrderService.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.ppm.delivery.order.producer.service;
 
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,7 +13,7 @@ public class OrderService implements IOrderService{
     }
 
     @Override
-    public void sendCreateOrderMessage(String message){
-        senderMessageService.sendCreateOrderMessage(message);
+    public void sendCreateOrderMessage(OrderRequest request){
+        senderMessageService.sendCreateOrderMessage(request);
     }
 }

--- a/producer/src/main/java/com/ppm/delivery/order/producer/service/SenderMessageService.java
+++ b/producer/src/main/java/com/ppm/delivery/order/producer/service/SenderMessageService.java
@@ -2,12 +2,14 @@ package com.ppm.delivery.order.producer.service;
 
 import com.ppm.delivery.order.producer.api.constants.ActionMessageConstants;
 import com.ppm.delivery.order.producer.api.context.ContextHolder;
+import com.ppm.delivery.order.producer.api.domain.request.OrderRequest;
 import com.ppm.delivery.order.producer.message.config.MessageHeaderConstants;
 import com.ppm.delivery.order.producer.message.config.QueueConfig;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -18,34 +20,36 @@ public class SenderMessageService implements ISenderMessageService{
     private final ContextHolder contextHolder;
     private final QueueConfig queueConfig;
     private final RabbitTemplate rabbitTemplate;
+    private final MessageConverter messageConverter;
 
 
     public SenderMessageService(final ContextHolder contextHolder,
                                 final QueueConfig queueConfig,
-                                final RabbitTemplate rabbitTemplate) {
+                                final RabbitTemplate rabbitTemplate,
+                                final MessageConverter messageConverter) {
         this.contextHolder = contextHolder;
         this.queueConfig = queueConfig;
         this.rabbitTemplate = rabbitTemplate;
+        this.messageConverter = messageConverter;
     }
 
     @Override
-    public void sendCreateOrderMessage(Object payload) {
+    public void sendCreateOrderMessage(OrderRequest request) {
 
         String routingKey = queueConfig.getRoutingKey(contextHolder.getCountry(), ActionMessageConstants.CREATE);
 
-        Message message = createMessage(payload);
+        Message message = createMessage(request);
 
         rabbitTemplate.convertAndSend(queueConfig.getExchangeName(), routingKey, message);
     }
 
-    private Message createMessage(Object payload) {
+    private Message createMessage(OrderRequest request) {
         MessageProperties messageProperties = new MessageProperties();
         messageProperties.setHeader(MessageHeaderConstants.HEADER_COUNTRY, contextHolder.getCountry());
         messageProperties.setHeader(MessageHeaderConstants.HEADER_CORRELATION_ID, contextHolder.getCorrelationId());
         messageProperties.setHeader(MessageHeaderConstants.HEADER_PROFILE, contextHolder.getProfile());
         messageProperties.setHeader(MessageHeaderConstants.HEADER_TIMESTAMP, LocalDateTime.now().toString());
 
-        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter();
-        return converter.toMessage(payload, messageProperties);
+        return messageConverter.toMessage(request, messageProperties);
     }
 }


### PR DESCRIPTION
- Refatorado o controller para aceitar OrderRequest como payload no endpoint POST /order/create.

- Atualizado método sendCreateOrderMessage para construir e enviar a mensagem com base no OrderRequest.

- Implementado método createMessage para adicionar headers padrão ao contexto da mensagem.

- Adicionados enums representando os valores dos campos controlados no contrato.

- Aplicadas validações nos campos obrigatórios do OrderRequest.