### PR TITLE
[0002-14] fix: workflows to run on pull requests targeting main

### DIFF
--- a/.github/workflows/ci-consumer.yml
+++ b/.github/workflows/ci-consumer.yml
@@ -2,11 +2,11 @@ name: CI Consumer
 
 on:
   pull_request:
-    paths:
-      - 'consumer/**'
+    branches:
+      - main
 
 jobs:
-  build-producer:
+  build-consumer:
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/ci-producer.yml
+++ b/.github/workflows/ci-producer.yml
@@ -2,8 +2,8 @@ name: CI Producer
 
 on:
   pull_request:
-    paths:
-      - 'producer/**'
+    branches:
+      - main
 
 jobs:
   build-producer:


### PR DESCRIPTION
- Os workflows do GitHub Actions (ci-consumer.yml e ci-producer.yml) foram ajustados para rodar em todo pull request direcionado à branch main.

- Essa mudança garante que os status checks apareçam corretamente e possam ser configurados como obrigatórios nas regras de proteção de branch.

- Prepara a base para habilitar os required status checks para consumer e producer.