### PR TITLE
[0002-10] feat : (consumer) Initial implementation of Order domain: add modeling classes, mapper, service and repository with MongoDB configuration (BR/MX collections) and infra adjustments (yml, docker-compose, pom)

### DIFF
--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -17,12 +17,29 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
     </dependencies>
 
@@ -33,6 +50,28 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.ppm.delivery.order.consumer.PpmDeliveryOrderConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.34</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/PpmDeliveryOrderConsumerApplication.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/PpmDeliveryOrderConsumerApplication.java
@@ -2,8 +2,10 @@ package com.ppm.delivery.order.consumer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class PpmDeliveryOrderConsumerApplication {
     public static void main(String[] args) {
         SpringApplication.run(PpmDeliveryOrderConsumerApplication.class, args);

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/context/ContextHolder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/context/ContextHolder.java
@@ -20,7 +20,7 @@ public class ContextHolder {
         contextHolder.set(context);
     }
 
-    public Map<String, String> getContext() {
+    private Map<String, String> getContext() {
         return contextHolder.get();
     }
 
@@ -28,6 +28,14 @@ public class ContextHolder {
         setCountry(country);
         setCorrelationId(requestTraceId);
         setTimestamp(timestamp);
+    }
+
+    public String getCountry(){
+        return getContext().get(COUNTRY);
+    }
+
+    public void clear() {
+        contextHolder.remove();
     }
 
     private void setCountry(final String country) {
@@ -48,7 +56,4 @@ public class ContextHolder {
         }
     }
 
-    public void clear() {
-        contextHolder.remove();
-    }
 }

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/mapper/OrderMapper.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/mapper/OrderMapper.java
@@ -1,0 +1,16 @@
+package com.ppm.delivery.order.consumer.domain.mapper;
+
+import com.ppm.delivery.order.consumer.domain.model.Order;
+import com.ppm.delivery.order.consumer.message.domain.OrderMessage;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface OrderMapper {
+
+    Order toEntity(OrderMessage message);
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/AuditOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/AuditOrder.java
@@ -1,0 +1,21 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditOrder {
+
+    private LocalDateTime createAt;
+
+    private LocalDateTime updateAt;
+
+    public AuditOrder(LocalDateTime createAt){
+        this.createAt = createAt;
+    }
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/CupomOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/CupomOrder.java
@@ -1,0 +1,28 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.DiscountType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CupomOrder {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    @PositiveOrZero
+    private BigDecimal discount;
+
+    @NotNull
+    private DiscountType discountType;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/CustomerInfoOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/CustomerInfoOrder.java
@@ -1,0 +1,23 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerInfoOrder {
+
+    @NotBlank
+    private String id;
+
+    @Email
+    @NotBlank
+    @Size(max = 255, message = "Email must not exceed 255 characters")
+    private String email;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/DeliveryInfoOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/DeliveryInfoOrder.java
@@ -1,0 +1,18 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeliveryInfoOrder {
+
+    @NotNull
+    @Valid
+    private LocationOrder location;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/GeoCoordinatesOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/GeoCoordinatesOrder.java
@@ -1,0 +1,25 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GeoCoordinatesOrder {
+
+    @NotNull
+    @Min(value = -90, message = "Latitude must be greater than or equal to -90")
+    @Max(value = 90, message = "Latitude must be less than or equal to 90")
+    private Double latitude;
+
+    @NotNull
+    @Min(value = -180, message = "Longitude must be greater than or equal to -180")
+    @Max(value = 180, message = "Longitude must be less than or equal to 180")
+    private Double longitude;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/ItemOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/ItemOrder.java
@@ -1,0 +1,49 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.ItemCategory;
+import com.ppm.delivery.order.consumer.domain.enums.ItemTemperature;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ItemOrder {
+
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private String sku;
+
+    @NotNull
+    private ItemCategory category;
+
+    @NotBlank
+    private String brand;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private Boolean alcoholic;
+
+    @NotNull
+    private ItemTemperature temperature;
+
+    @NotNull
+    @Valid
+    private PackageInfoOrder packageInfo;
+
+    @NotEmpty
+    @Valid
+    private List<@Valid PriceOrder> price;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/LocationOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/LocationOrder.java
@@ -1,0 +1,39 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LocationOrder {
+
+    @NotNull
+    @Valid
+    private GeoCoordinatesOrder geoCoordinates;
+
+    @NotBlank
+    private String city;
+
+    @NotBlank
+    private String country;
+
+    @NotBlank
+    private String state;
+
+    @NotBlank
+    private String number;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{5}-?\\d{3}", message = "Invalid ZIP code, use the format 00000-000")
+    private String zipCode;
+
+    @NotBlank
+    private String streetAddress;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/Order.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/Order.java
@@ -1,0 +1,55 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.Status;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document
+public class Order {
+
+    @Id
+    private String id;
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    private LocalDateTime createDate;
+
+    @NotNull
+    private Status status;
+
+    @NotNull
+    @Valid
+    private CustomerInfoOrder customerInfo;
+
+    @NotNull
+    @Valid
+    private DeliveryInfoOrder deliveryInfo;
+
+    @NotNull
+    @Valid
+    private List<@Valid ItemOrder> items;
+
+    @NotNull
+    @Valid
+    private PaymentOrder payment;
+
+    @Valid
+    private CupomOrder cupom;
+
+    private AuditOrder audit;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PackageInfoOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PackageInfoOrder.java
@@ -1,0 +1,33 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.PackageType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PackageInfoOrder {
+
+    @NotNull
+    @Positive
+    private Integer itemCount;
+
+    @NotNull
+    private PackageType type;
+
+    @NotBlank
+    private String unitOfMeasurement;
+
+    @NotNull
+    private Boolean returnable;
+
+    @NotNull
+    @Positive
+    private Integer size;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PaymentOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PaymentOrder.java
@@ -1,0 +1,47 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.DiscountType;
+import com.ppm.delivery.order.consumer.domain.enums.PaymentMethod;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentOrder {
+
+    @NotNull
+    private PaymentMethod method;
+
+    @NotNull
+    @PositiveOrZero
+    private BigDecimal discount;
+
+    @NotNull
+    private DiscountType discountType;
+
+    @NotNull
+    @Positive
+    private BigDecimal total;
+
+    @NotNull
+    @PositiveOrZero
+    private BigDecimal taxAmount;
+
+    @NotNull
+    @Positive
+    private BigDecimal price;
+
+    @NotNull
+    @Valid
+    private List<@Valid TaxOrder> taxes;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PriceOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/PriceOrder.java
@@ -1,0 +1,39 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import com.ppm.delivery.order.consumer.domain.enums.PriceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PriceOrder {
+
+    @NotBlank
+    private String id;
+
+    @NotNull
+    private PriceType type;
+
+    @NotNull
+    @Positive
+    private BigDecimal price;
+
+    @NotNull
+    @Positive
+    private BigDecimal total;
+
+    @NotNull
+    @PositiveOrZero
+    private BigDecimal discountAmount;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/TaxOrder.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/domain/model/TaxOrder.java
@@ -1,0 +1,24 @@
+package com.ppm.delivery.order.consumer.domain.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaxOrder {
+
+    @NotBlank
+    private String id;
+
+    @NotNull
+    @Positive
+    private BigDecimal value;
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/message/config/MongoConfig.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/message/config/MongoConfig.java
@@ -1,0 +1,19 @@
+package com.ppm.delivery.order.consumer.message.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+
+@Configuration
+public class MongoConfig {
+
+    @Autowired
+    private MappingMongoConverter mappingMongoConverter;
+
+    @PostConstruct
+    public void setUp() {
+        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/message/listener/OrderCreateListener.java
@@ -3,6 +3,7 @@ package com.ppm.delivery.order.consumer.message.listener;
 import com.ppm.delivery.order.consumer.message.constants.HeaderConstants;
 import com.ppm.delivery.order.consumer.context.ContextHolder;
 import com.ppm.delivery.order.consumer.message.domain.OrderMessage;
+import com.ppm.delivery.order.consumer.service.IOrderService;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -13,8 +14,12 @@ public class OrderCreateListener {
 
     private final ContextHolder contextHolder;
 
-    public OrderCreateListener(ContextHolder contextHolder) {
+    private final IOrderService orderService;
+
+    public OrderCreateListener(ContextHolder contextHolder,
+                               IOrderService orderService) {
         this.contextHolder = contextHolder;
+        this.orderService = orderService;
     }
 
     @RabbitListener(queues = "#{@rabbitConfig.queueNames()}",
@@ -28,11 +33,14 @@ public class OrderCreateListener {
         contextHolder.initializeContextValues(country, correlationId, timestamp);
 
         try {
+            orderService.createOrder(message);
+
             System.out.println("Routing key: " + routingKey);
             System.out.println("Country: " + country);
             System.out.println("Correlation ID: " + correlationId);
             System.out.println("Timestamp: " + timestamp);
             System.out.println("Mensagem: " + message);
+
 
         } finally {
             contextHolder.clear();

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/DatabaseProperties.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/properties/DatabaseProperties.java
@@ -1,0 +1,15 @@
+package com.ppm.delivery.order.consumer.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.data.mongodb")
+public class DatabaseProperties {
+
+    private String collectionName;
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/repository/IOrderRepository.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/repository/IOrderRepository.java
@@ -1,0 +1,10 @@
+package com.ppm.delivery.order.consumer.repository;
+
+import com.ppm.delivery.order.consumer.domain.model.Order;
+
+
+public interface IOrderRepository {
+
+    void save(final String country, Order order);
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/repository/OrderRepository.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/repository/OrderRepository.java
@@ -1,0 +1,29 @@
+package com.ppm.delivery.order.consumer.repository;
+
+import com.ppm.delivery.order.consumer.domain.model.Order;
+import com.ppm.delivery.order.consumer.properties.DatabaseProperties;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class OrderRepository implements IOrderRepository {
+
+    private final DatabaseProperties databaseProperties;
+    private final MongoOperations mongoOperations;
+
+    public OrderRepository(DatabaseProperties databaseProperties, MongoOperations mongoOperations){
+        this.databaseProperties = databaseProperties;
+        this.mongoOperations = mongoOperations;
+    }
+
+    @Override
+    public void save(final String country, Order order){
+
+        mongoOperations.save(order, getCollectionName(country));
+    }
+
+    private String getCollectionName(final String country){
+        return country.toUpperCase() + "-" + databaseProperties.getCollectionName();
+    }
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/service/IOrderService.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/service/IOrderService.java
@@ -1,0 +1,9 @@
+package com.ppm.delivery.order.consumer.service;
+
+import com.ppm.delivery.order.consumer.message.domain.OrderMessage;
+
+public interface IOrderService {
+
+    void createOrder(OrderMessage message);
+
+}

--- a/consumer/src/main/java/com/ppm/delivery/order/consumer/service/OrderService.java
+++ b/consumer/src/main/java/com/ppm/delivery/order/consumer/service/OrderService.java
@@ -1,0 +1,36 @@
+package com.ppm.delivery.order.consumer.service;
+
+import com.ppm.delivery.order.consumer.context.ContextHolder;
+import com.ppm.delivery.order.consumer.domain.mapper.OrderMapper;
+import com.ppm.delivery.order.consumer.domain.model.AuditOrder;
+import com.ppm.delivery.order.consumer.domain.model.Order;
+import com.ppm.delivery.order.consumer.message.domain.OrderMessage;
+import com.ppm.delivery.order.consumer.repository.IOrderRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class OrderService implements IOrderService{
+
+    private final IOrderRepository orderRepository;
+    private final OrderMapper orderMapper;
+    private final ContextHolder contextHolder;
+
+    public OrderService(final IOrderRepository orderRepository,
+                        final OrderMapper orderMapper,
+                        final ContextHolder contextHolder){
+        this.orderRepository = orderRepository;
+        this.orderMapper = orderMapper;
+        this.contextHolder = contextHolder;
+    }
+
+    @Override
+    public void createOrder(OrderMessage message){
+        Order order = orderMapper.toEntity(message);
+        order.setAudit(new AuditOrder(LocalDateTime.now()));
+        orderRepository.save(contextHolder.getCountry(), order);
+
+    }
+
+}

--- a/consumer/src/main/resources/application.yml
+++ b/consumer/src/main/resources/application.yml
@@ -8,6 +8,12 @@ spring:
     username: guest
     password: guest
 
+  data:
+    mongodb:
+      uri: mongodb://root:example@localhost:27017/${spring.data.mongodb.database}?authSource=admin
+      database: database-order
+      collectionName: Order
+
 app:
   supportedCountries:
     - AR
@@ -20,5 +26,7 @@ app:
 message:
   rabbitmq:
     domain: order
-    actions: create, update
+    actions:
+      - create
+      - update
     exchange: order.command.exchange

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,18 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
+
+  mongodb:
+    image: mongo:7.0
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_DATABASE: orders_db
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:

--- a/producer/pom.xml
+++ b/producer/pom.xml
@@ -24,6 +24,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
- Adicionadas classes de modelagem de domínio (Order, CustomerInfoOrder, ItemOrder, PaymentOrder, etc.).

- Criado OrderMapper para conversão de mensagens em entidades de domínio.

- Implementados OrderService e IOrderService para lidar com regras de negócio.

- Adicionados OrderRepository e IOrderRepository para a camada de persistência.

- Configuração do MongoDB com coleções por país (BR-Order, MX-Order).

- Ajustes de infraestrutura:

    - application.yml com propriedades de banco de dados.

    - MongoConfig para remover _class dos documentos.

    - Atualizações em docker-compose.yml e pom.xml.